### PR TITLE
Replace the network icon with the remote folder icon

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -31,7 +31,7 @@ class Indicator extends PanelMenu.Button {
     super._init(0.0, _('OpenAFS Status'));
 
     const icon = new St.Icon({
-      icon_name: 'network-wired-symbolic',
+      icon_name: 'folder-remote-symbolic',
       style_class: 'system-status-icon',
     });
     this.add_child(icon);


### PR DESCRIPTION
The network icon is confusing for this extension, since we are not starting a network connection with this, but rather mounting a remote folder called /afs.

Replace the network icon with the standard remote folder icon to make it clear this is mounting a folder on a shared filesystem.