### PR TITLE
Avoid "omitting directory" warning during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ GNOME extensions should be placed in a specific folder:
 
 ```bash
 mkdir -p ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs
-cp * ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/
+cp -v -r * ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/
 ```
 
 


### PR DESCRIPTION
Add the -r option to the cp command when installing the extension to avoid an "omitting directory" warning. Also add the -v option to show which files are being copied.

This installs assets directory and the screenshot.png which is not required to be installed.  Later, we can add more assets in that directory, so they will need to be installed.

The README.md and screenshot.png files are not needed to run the extension, but are small and this keeps the install commands simple.

This change does not install the git files (.git/* and .gitinfo), which should not be installed.

Before this change:

    $ cp * ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/
    cp: -r not specified; omitting directory 'assets'

After this change:

    $ cp -v -r * ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/
    'assets/screenshot.png' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/assets/screenshot.png'
    'extension.js' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/extension.js'
    'indicator.js' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/indicator.js'
    'metadata.json' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/metadata.json'
    'README.md' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/README.md'
    'stylesheet.css' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/stylesheet.css'
    'utils.js' -> '/home/username/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/utils.js'